### PR TITLE
Correct removeReturns function

### DIFF
--- a/app.js
+++ b/app.js
@@ -40,7 +40,7 @@ function tokenizeText(text) {
 
 
 function removeReturns(text) {
-  return text.replace(/\r?\n|\r/g, "");
+  return text.replace(/\r?\n|\r/g, " ");
 }
 
 


### PR DESCRIPTION
needs the space (or some other character later used in regex) instead of empty string which effectively joins the last word of one line with the first word of another. Fixes issue #5 .